### PR TITLE
Fix keyboard backlight and hevc (h.265) playback

### DIFF
--- a/sparse/etc/gst-droid/gstdroidcodec.conf
+++ b/sparse/etc/gst-droid/gstdroidcodec.conf
@@ -1,0 +1,3 @@
+[decoders]
+video/hevc=1
+

--- a/sparse/etc/mce/91-keyboard-backlight.ini
+++ b/sparse/etc/mce/91-keyboard-backlight.ini
@@ -1,0 +1,2 @@
+[KeyPad]
+BrightnessDirectory=/sys/class/leds/keyboard-backlight


### PR DESCRIPTION
Added two configuration files to fix keyboard backlight (using mce and elros34's suggestion) and hevc decoding (using mal's help and nile's configuration example).