### PR TITLE
[pattern] Dont install the early developer tools

### DIFF
--- a/rpm/jolla-configuration-t5.spec
+++ b/rpm/jolla-configuration-t5.spec
@@ -10,18 +10,6 @@ Requires: patterns-sailfish-applications
 Requires: patterns-sailfish-ui
 Requires: patterns-sailfish-store-applications
 
-# Early stages of porting benefit from these:
-#Requires: sailfish-porter-tools
-Requires: jolla-developer-mode
-Requires: sailfishsilica-qt5-demos
-Requires: busybox-static
-Requires: net-tools
-Requires: openssh-clients
-Requires: openssh-server
-Requires: vim-enhanced
-Requires: zypper
-Requires: strace
-
 # jolla-rnd-device will enable usb-moded even when UI is not yet
 # brought up (useful during development, available since update10)
 Requires: jolla-rnd-device


### PR DESCRIPTION
This should not be here becuase removing developer-mode from the UI will
remove jolla-configuration-t5, and noone will be happy with that.