### PR TITLE
[usb] Allow connman to use the usb0 interface used on this device.

### DIFF
--- a/sparse/etc/connman/main-native.conf
+++ b/sparse/etc/connman/main-native.conf
@@ -1,0 +1,17 @@
+[General]
+
+FallbackTimeservers = 0.sailfishos.pool.ntp.org,1.sailfishos.pool.ntp.org,2.sailfishos.pool.ntp.org,3.sailfishos.pool.ntp.org
+NetworkInterfaceBlacklist = p2p,rmnet,rev_rmnet
+SingleConnectedTechnology = false
+Ipv4StatusUrl = http://ipv4.jolla.com/return_204
+Ipv6StatusUrl = http://ipv6.jolla.com/return_204
+PreferredTechnologies = bluetooth,wifi,cellular
+PersistentTetheringMode = false
+AllowHostnameUpdates = false
+TetheringSubnetBlock = 172.28.172.0
+DontBringDownAtStartup = rndis
+InputRequestTimeout = 300
+# ConnMan will create dir "connman", no need to define here.
+StorageRoot = /home/.system/var/lib
+StateDir = /run
+

--- a/sparse/etc/usb-moded/dyn-modes/99-developer_mode-native.ini
+++ b/sparse/etc/usb-moded/dyn-modes/99-developer_mode-native.ini
@@ -1,0 +1,16 @@
+[mode]
+name = developer_mode
+module = none
+network = 1
+network_interface = usb0
+appsync = 1
+
+[options]
+sysfs_path = /sys/class/android_usb/android0/functions
+sysfs_value = rndis
+sysfs_reset_value = none
+softconnect_path = /sys/class/android_usb/android0/enable
+softconnect = 1
+softconnect_disconnect = 0
+idProduct = 0A02
+dhcp_server = 1

--- a/sparse/var/lib/environment/connman/override-main-config.conf
+++ b/sparse/var/lib/environment/connman/override-main-config.conf
@@ -1,0 +1,1 @@
+CONNMAN_ARGS="--config=/etc/connman/main-native.conf"


### PR DESCRIPTION
Usually, the interface name is rndis0, but here it is usb0 which is
usually disabled for connman.