### PR TITLE
Enable support for external mouse by default

### DIFF
--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -2,4 +2,4 @@
 EGL_PLATFORM=hwcomposer
 QT_QPA_PLATFORM=hwcomposer
 
-LIPSTICK_OPTIONS=-plugin evdevtouch:/dev/input/event1 -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap
+LIPSTICK_OPTIONS=-plugin evdevtouch:/dev/input/event1 -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap -plugin evdevmouse


### PR DESCRIPTION
Extra packages will be required for cursor visibility and coordinates rotation (see #41), but there should be no drawback to enabling this plugin by default.